### PR TITLE
Added nickname validation

### DIFF
--- a/Software-Code/Quizzarr/Controllers/QuizController.cs
+++ b/Software-Code/Quizzarr/Controllers/QuizController.cs
@@ -186,6 +186,8 @@ namespace Quizzarr.Controllers
             }
             if (user == null) return NotFound();
 
+            if (GetNicknameInSession(user.DisplayName, joinSession)) return NotFound();
+
             LobbyUsers.Remove(user);
             PrintLobbyUsers();
             joinSession.Users.Add(user);
@@ -422,6 +424,14 @@ namespace Quizzarr.Controllers
                     return u;
 
             return null;
+        }
+
+        public bool GetNicknameInSession(string nickname, GameSession session) {
+            foreach (User u in session.Users)
+                if (nickname.Equals(u.DisplayName))
+                    return true;
+
+            return false;
         }
 
         public User GetUserInLobby(string userID) {


### PR DESCRIPTION
When a user joins a session, if the display name that they chose already exists in that session, they will not be allowed to enter. This means that each user per session has a unique name, but that name can be found in multiple sessions.

Closes #53 