### PR TITLE
Updated answer comparison

### DIFF
--- a/Software-Code/Quizzarr/Controllers/QuizController.cs
+++ b/Software-Code/Quizzarr/Controllers/QuizController.cs
@@ -306,7 +306,7 @@ namespace Quizzarr.Controllers
             user.Answered = true;
 
             bool ans = false;
-            if (answer.Equals(curSession.Questions[qIndex].answer)) {
+            if (answer.ToLower().Equals(curSession.Questions[qIndex].answer.ToLower())) {
                 ans = true;
 
             }

--- a/Software-Code/Quizzarr/Data/SqlQuestionRepo.cs
+++ b/Software-Code/Quizzarr/Data/SqlQuestionRepo.cs
@@ -84,7 +84,7 @@ namespace Quizzarr.Data
                     List<string> _altAnswers = __altAnswers;
 
                     questions.Add( new Question(_id, _type, _question, _answer, _topic, _multiChoice_ID, _numCorrect, _numIncorrect, _difficulty, _altAnswers));
-                } catch (Exception e) {
+                } catch (Exception) {
                     System.Console.WriteLine("Error Occured with index - " + index);
                 }
                 index++;


### PR DESCRIPTION
When comparing the answer string to the correct answer, both are not cast to a lowercase version. This will mean that any TrueFalse questions that have an answer that is not in the desired format will not cause issues.

Closes #60 