### PR TITLE
BugFix - Answer with a null answer

### DIFF
--- a/Software-Code/Quizzarr/Controllers/QuizController.cs
+++ b/Software-Code/Quizzarr/Controllers/QuizController.cs
@@ -317,9 +317,11 @@ namespace Quizzarr.Controllers
             user.Answered = true;
 
             bool ans = false;
-            if (answer.ToLower().Equals(curSession.Questions[qIndex].answer.ToLower())) {
+            if (answer == null) {
+                // This catches any null answers and treats them as an incorrect answer
+                // Do nothing as the ans variable is already set to null
+            } else if (answer.ToLower().Equals(curSession.Questions[qIndex].answer.ToLower())) {
                 ans = true;
-
             }
             GetUserInSession(findSessionWithUser(userID), userID).MyScore.UpdateScore(ans);
             


### PR DESCRIPTION
The submitAnswer function now successfully handles a null answer.

This is assuming the user has not submitted an answer in time and therefore it treats it as an incrorrect answer

Closes #65 